### PR TITLE
Server side html cleanup

### DIFF
--- a/wysihtml5/fields.py
+++ b/wysihtml5/fields.py
@@ -2,15 +2,25 @@
 
 from django.db.models import fields
 
+from wysihtml5.utils import keeptags
 from wysihtml5.widgets import Wysihtml5AdminTextareaWidget
 
 
 class Wysihtml5TextField(fields.TextField):
+    def __init__(self, *args, **kwargs):
+        self.keep_tags = kwargs.pop('keep_tags', 'h1 h2 h3 h4 h5 h6 div p i u'
+                                    ' ul ol li span img a blockquote')
+        super(Wysihtml5TextField, self).__init__(*args, **kwargs)
 
     def formfield(self, **kwargs):
         defaults = {"widget": Wysihtml5AdminTextareaWidget}
         defaults.update(kwargs)
         return super(Wysihtml5TextField, self).formfield(**defaults)
+
+    def pre_save(self, model_instance, add):
+        value = super(Wysihtml5TextField, self).pre_save(model_instance, add)
+        return keeptags(value, self.keep_tags)
+
 
 try:
     from south.modelsinspector import add_introspection_rules

--- a/wysihtml5/utils.py
+++ b/wysihtml5/utils.py
@@ -1,6 +1,9 @@
 #-*- coding: utf-8 -*-
 
+import re
+
 from django.core.exceptions import ImproperlyConfigured
+from django.utils.functional import allow_lazy
 from django.utils.importlib import import_module
 
 
@@ -15,3 +18,16 @@ def get_function(function_path):
         raise ImproperlyConfigured(('Error importing module %s: "%s"' %
                                    (mod_name, e)))
     return getattr(mod, func_name)
+
+
+def keeptags(value, tags):
+    tags = [re.escape(tag) for tag in tags.split()]
+
+    def _replacer(match):
+        if match.group(1) in tags:
+            return match.group(0)
+        else:
+            return u''
+
+    return re.sub(r'</?([^> ]+).*?>', _replacer, value)
+keeptags = allow_lazy(keeptags)


### PR DESCRIPTION
Now we can have a list of allowed tags!

It is possible to add something like

```
<script>alert('Ops');</script>
```

to the message. Using  |safe filter becomes dangerous. That patch makes server validation possible.

There are at least two ways to add <script> and bypass client side validation: to disable javascript in your browser or tamper request value. It's always required to validate user's data on server side.
