### PR TITLE
Convert INSTALLED_APPS to list before concat

### DIFF
--- a/wysihtml5/tests/__init__.py
+++ b/wysihtml5/tests/__init__.py
@@ -28,7 +28,8 @@ def suite():
     else:
         from django.db.models.loading import load_app
         from django.conf import settings
-        settings.INSTALLED_APPS = settings.INSTALLED_APPS + ['wysihtml5.tests',]
+        settings.INSTALLED_APPS = list(settings.INSTALLED_APPS) + \
+                                  ['wysihtml5.tests']
         map(load_app, settings.INSTALLED_APPS)
 
     from wysihtml5.tests import fields, widgets


### PR DESCRIPTION
Django settings.INSTALLED_APPS can be a tuple. To be sure only list + list are concatenated settings.INSTALLED_APPS is converted to a list before adding ['wysihtml5.tests'].
