### PR TITLE
Template url deprecated in django 1.5

### DIFF
--- a/example/demo/templates/articles/article_detail.html
+++ b/example/demo/templates/articles/article_detail.html
@@ -20,6 +20,6 @@
     {{ object.body|safe }}
   </div>
   <hr/>
-  <p><a href="{% url articles-index %}">back to the articles list</a></p>
+  <p><a href="{% url 'articles-index' %}">back to the articles list</a></p>
 </div>
 {% endblock %}

--- a/example/demo/templates/homepage.html
+++ b/example/demo/templates/homepage.html
@@ -12,7 +12,7 @@
 <div class="container">
   <p>The demo site has an Articles App with a model <code>Article</code> whose field <code>body</code> uses a widget based on the rich text editor <a href="https://github.com/xing/wysihtml5">Wysihtml5</a>.</p>
   <ul>
-    <li><a href="{% url articles-index %}">Article list</a></li>
+    <li><a href="{% url 'articles-index' %}">Article list</a></li>
   </ul>
   <hr/>
   <p style="text-align:right">


### PR DESCRIPTION
Hey,

I was messing a bit with your example and django was throwing errors about the url function you used in some of your templates. Apparently using it without quotes is now deprecated. 
- Mike
